### PR TITLE
add Python Community to the slack groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A list of communities about web development and design that are powered by [Slac
 - [Cordova](http://slack.cordova.io/)
 - [Atom](http://atom-slack.herokuapp.com/)
 - [Quokka CMS](https://quokkaslack.herokuapp.com/)
+- [Python Community](https://pythoncommunity.herokuapp.com/)
 - [#ruby, #python, #nodejs, #php, #go, #fed](http://www.hashtagdevelopers.com/)
 
 


### PR DESCRIPTION
Please add the Python Community slack group to your list. I've been using it for a few months and its been helpful. 

I have a few others that I'll add shortly.